### PR TITLE
Update meta.yaml

### DIFF
--- a/recipes/xrftomo/meta.yaml
+++ b/recipes/xrftomo/meta.yaml
@@ -14,11 +14,9 @@ build:
   noarch: python
   number: 0
   skip: True [py<36] 
-  script: "{{ PYTHON }} -m pip install . -vv"
+  script: "{{ PYTHON }} -m pip install . --no-deps -vv"
 
 requirements:
-  build:
-
   host:
     - python
     - pip
@@ -29,7 +27,6 @@ requirements:
     - git
     - h5py
     - numpy
-    - python=3.7
     - scikit-image
     - scipy
     - dxchange
@@ -46,7 +43,7 @@ about:
   license: BSD-3
   license_family: BSD
   license_file: LICENSE.txt
-  summary: 'tomography software for APS beamlines'
+  summary: 'Tomography software for APS beamlines'
 
   description: |
     XRFtomo brings together a variety of image processing tools used for preparing, 
@@ -55,7 +52,7 @@ about:
     Advanced Photon Source (APS).
 
   doc_url: https://xrftomo.readthedocs.io/en/latest/
-  dev_url: https://github.com/FabricioSMarin/XRFtomo
+  dev_url: https://github.com/tomography/XRFtomo
 
 extra:
   recipe-maintainers:


### PR DESCRIPTION
Removed empty `build` section, removed hard coded Python version spec, updated `dev_url` to the shared repository. Added no dependencies option to the pip install command.

# Comments

- [x] Do you need a pyqt version specification? It looks like you are importing PyQt5 so maybe pyqt needs to be at least 5?
- [x] Please double check the run requirements by searching the XRFtomo module headers for "import".